### PR TITLE
Updates to support building on Mac, via Docker, and with Ubuntu > 12.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.lss
 *.map
 *.sym
+
+# build log
+GTVHacker-build.log

--- a/Dev/build.sh
+++ b/Dev/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Change to the directory containing this script
+cd "$(dirname "$0")"
+
+
 #Redirect output to log
 exec 3>&1 1>>GTVHacker-build.log 2>&1
 set -x
@@ -75,7 +79,7 @@ if [ ! -f omap3_usbload/omap3_usbload ]
     fi
 
 echo "[I] - Copying files to \"Release\" directory." 1>&3
-cp u-boot/u-boot.bin ../Release/Nest/ 
+cp u-boot/u-boot.bin ../Release/Nest/
 cp x-loader/x-load.bin ../Release/Nest/
 cp linux/arch/arm/boot/uImage ../Release/Nest/
 cp omap3_usbload/omap3_usbload ../Release/Linux/

--- a/Dev/linux/kernel/timeconst.pl
+++ b/Dev/linux/kernel/timeconst.pl
@@ -347,7 +347,7 @@ if ($hz eq '--can') {
 	foreach $hz (@hzlist) {
 		my @values = compute_values($hz);
 		print "$pf$hz => [\n";
-		while (scalar(@values)) {
+		while (@values) {
 			my $bit;
 			foreach $bit (32) {
 				my $m = shift(@values);
@@ -370,7 +370,7 @@ if ($hz eq '--can') {
 	}
 
 	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
+	if (!@val) {
 		@val = compute_values($hz);
 	}
 	output($hz, @val);

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM amd64/ubuntu:18.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install essential build tools and dependencies
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic main universe" && \
+    add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic-updates main universe" && \
+    dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    make \
+    wget \
+    bzip2 \
+    git \
+    libncurses-dev \
+    u-boot-tools \
+    bc \
+    gcc-multilib \
+    g++-multilib \
+    lib32gcc1 \
+    libc6-i386 \
+    lib32stdc++6 \
+    perl \
+    flex \
+    bison \
+    libssl-dev \
+    linux-headers-generic \
+    libusb-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace directory
+WORKDIR /workspace
+
+# Copy the project files
+COPY . .
+
+# Create Release directories
+RUN mkdir -p Release/Nest Release/Linux
+
+# Make build script executable
+RUN chmod +x Dev/build.sh
+
+# Set default command
+CMD ["/bin/bash"]

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,0 +1,27 @@
+# MacOS helper scripts
+
+## `make_sensitive.sh`
+
+
+Commonly, MacOS volumes are case-insensitive, which means that you can have two files with the same name but different cases. This is a problem for us because the NestDFUAttack repository has numerous files which differ only by case, and hence cannot be used on a case-insensitive volume.
+
+Create a case-sensitive dmg filesystem image, mount it at `/Volumes/CaseSensitiveVolume`, and clone the [rick/NestDFUAttack](https://github.com/rick/NestDFUAttack) repository fork into it.
+
+```bash
+./make_sensitive.sh
+```
+
+## Building the Docker image and rebuilding the NestDFUAttack distribution
+
+The original NestDFUAttack distribution is based on Ubuntu 12.04, which is fairly out of date (and accessing the apt repositories proved to be a bit difficult). Here we base the more modern build on Ubuntu 18.04 as a Docker image.  There are a couple of tweaks to the kernel build system which were needed to get it to fully compile.
+
+Rebuilding the NestDFUAttack distribution:
+
+```bash
+# Mac: cd /Volumes/CaseSensitiveVolume/NestDFUAttack
+docker build -t nest-build .
+docker run -it -v $(pwd):/workspace nest-build /workspace/Dev/build.sh
+```
+
+
+

--- a/mac/make_sensitive.sh
+++ b/mac/make_sensitive.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+
+umount /Volumes/CaseSensitiveVolume
+
+set -e
+
+rm -rf ~/Desktop/CaseSensitive.dmg.sparsebundle && \
+	hdiutil create -size 5g -type SPARSEBUNDLE -fs APFS -volname "TempVolume" ~/Desktop/CaseSensitive.dmg && \
+	hdiutil attach ~/Desktop/CaseSensitive.dmg.sparsebundle && \
+	sleep 2 && \
+	diskutil eraseVolume APFSX "CaseSensitiveVolume" /Volumes/TempVolume
+
+cd /Volumes/CaseSensitiveVolume
+
+git clone https://github.com/rick/NestDFUAttack.git


### PR DESCRIPTION
![robortluv](https://github.com/user-attachments/assets/48b4d713-2fcc-4fe9-b29c-87d058ebca50)

# General idea

Given that Google has decided to stop providing remote / cloud / app services for 1st and 2nd generation Nest thermostat devices (those devices which were designed, built, and sold by Nest before they were acquired by Google), and I have one of these that I've been actively using... I started wondering how to continue to find some way to read state and control the temperature while away from home.

There were some exploits and how-to's about using the USB connector on the devices to load a different boot initrd. These are a decade or so out of date and not much further (that I can see) was done with them. I figured, pull the code, make sure I can get the toolchain built (so that if I decide to mod things I can at least roll an updated toolchain and use it), and then see what I can find.

One scheme:

 - The device phones home to google/nest services, which have google/nest hostnames. These things are easy to spoof if the device is rooted, and ideally we can find a straightforward way to route that traffic to an owner-chosen subnet / IP.
 - Almost certainly the device software is expecting valid SSL/TSL certificates, and would balk at home-grown certs (or lack thereof).  Presumably firmware updates have shipped new upstream certs, etc. Presumably we could ship our own MITM certs to point to an owner-chosen network.
 - I feel certain the server-side protocol is full-on google-style OAuth funtimes wrapped around REST/SOAP/GRPC/whoknows. It could be that primarily we start with reading the state of the device, building a separate simple command and control server and start rebuilding the functionality that the device provides over the network.

I think if we get close to something like that we might provide a way for other people to run with things who are sitting on these devices. If not, it's probably fun for a bit,

### References

 - https://www.youtube.com/watch?v=H3tmvpi4YR0
 - https://www.exploitee.rs/index.php/Exploiting_Nest_Thermostats
 - https://www.tomsguide.com/home/smart-home/google-announces-end-of-support-for-1st-and-2nd-gen-nest-thermostats-what-you-need-to-know
 - https://blog.golioth.io/usb-docker-windows-macos/
 - https://nest-open-source.googlesource.com/nest-learning-thermostat/
 - https://www.ifixit.com/Teardown/Nest+Learning+Thermostat+2nd+Generation+Teardown/13818
 - https://hackaday.com/2014/06/24/rooting-the-nest-thermostat/
 - https://www.exploitee.rs/index.php/Nest_Hacking
 - https://community.home-assistant.io/t/rooting-to-save-the-nest-thermostat/119290/13
 - https://github.com/RunningFruits/arm-none-linux-gnueabi-gcc-files/blob/master/README.md
 - https://community.home-assistant.io/t/rooting-to-save-the-nest-thermostat/119290/13
 - 

## Updating the build

This PR is an experiment to see if I can get the original exploit at https://github.com/exploiteers/NestDFUAttack to build. These days I'm largely working from a MacOS environment, so I'm curious if I can a) get the project to `git clone` (due to case insensitivity issues on MacOS), b) build, c) figure out how to use this to do some hackery with my soon-to-be-EOL'd Nest Thermostat.

## The work

 - [x] make a case-sensitive MacOS .dmg file and mount it, into which I can actually check out the repository
 - [x] create a Dockerfile in which I can build the kernel and binaries (just to confirm that it can be built)
 - [x] ... using a more modern Linux than Ubuntu 12.04; currently at 18.04
   - [x] we need to tweak the perl build tooling with the old kernel a bit
 - [ ] ... perhaps use an even more modern Linux
   - I got into the weeds trying to make Ubuntu 22.04 happy, so 18.04 is the current high-water mark





